### PR TITLE
Allow using protobuf 4.X versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "panel>=1.2.1",
     "platformdirs>=3.8.0",
     "plotly>=5.16.1",
-    "protobuf~=3.20.2",
+    "protobuf>=3.20.2,<5",
     "six>=1.16.0",
     "tqdm>=4.45.0",
 ]


### PR DESCRIPTION
Extend the protobuf version range to include 4.X versions. Code generated with at least version 3.19 of the protoc compiler is compatible with the 4.X versions.
This corresponds to the `ansys-tools-protoc-helper` version `0.4.0` and later.

See also:
https://github.com/ansys/ansys-api-template/issues/10 
https://github.com/ansys/ansys-tools-protoc-helper#upgrade-plans