### PR TITLE
Update add-license-headers version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         files: src
 
   - repo: https://github.com/ansys/pre-commit-hooks
-    rev: v0.2.6
+    rev: v0.2.8
     hooks:
     - id: add-license-headers
       args:


### PR DESCRIPTION
- Update add-license-headers version to 0.2.8 to fix breaking pre-commit