### PR TITLE
update parametric study to check for duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### New Features
 * Add separate logging class
+* Update parametric study to check for duplicate entries
 
 ### Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-additive-core"
-version = "0.18.dev1"
+version = "0.18.dev2"
 description = "A Python client for the Ansys Additive service"
 readme = "README.rst"
 requires-python = ">=3.9,<4"

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -1236,19 +1236,16 @@ class ParametricStudy:
             raise ValueError(
                 f"Simulation status must be '{SimulationStatus.PENDING}' or '{SimulationStatus.SKIP}'"
             )
-        num_added = 0
         for input in inputs:
             dict = {}
             if isinstance(input, SingleBeadInput):
                 dict[ColumnNames.TYPE] = SimulationType.SINGLE_BEAD
                 dict[ColumnNames.SINGLE_BEAD_LENGTH] = input.bead_length
-                num_added += 1
             elif isinstance(input, PorosityInput):
                 dict[ColumnNames.TYPE] = SimulationType.POROSITY
                 dict[ColumnNames.POROSITY_SIZE_X] = input.size_x
                 dict[ColumnNames.POROSITY_SIZE_Y] = input.size_y
                 dict[ColumnNames.POROSITY_SIZE_Z] = input.size_z
-                num_added += 1
             elif isinstance(input, MicrostructureInput):
                 dict[ColumnNames.TYPE] = SimulationType.MICROSTRUCTURE
                 dict[ColumnNames.MICRO_MIN_X] = input.sample_min_x
@@ -1265,7 +1262,6 @@ class ParametricStudy:
                     dict[ColumnNames.MICRO_MELT_POOL_DEPTH] = input.melt_pool_depth
                 if input.random_seed != MicrostructureInput.DEFAULT_RANDOM_SEED:
                     dict[ColumnNames.RANDOM_SEED] = input.random_seed
-                num_added += 1
             else:
                 raise TypeError(f"Invalid simulation input type: {type(input)}")
 
@@ -1287,8 +1283,7 @@ class ParametricStudy:
             self._data_frame = pd.concat(
                 [self._data_frame, pd.Series(dict).to_frame().T], ignore_index=True
             )
-            num_added -= self._remove_duplicate_entries(overwrite=False)
-        return num_added
+        return len(inputs) - self._remove_duplicate_entries(overwrite=False)
 
     @save_on_return
     def _remove_duplicate_entries(self, overwrite: bool = False) -> int:

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -265,7 +265,7 @@ class ParametricStudy:
         summaries : list[SingleBeadSummary, PorositySummary, MicrostructureSummary]
             List of simulation result summaries to add to the parametric study.
         iteration : int, default: :obj:`DEFAULT_ITERATION`
-            Iteration number for the new simulations.
+            Iteration number(s) for the new simulation(s).
 
         Returns
         -------

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -1267,8 +1267,7 @@ class ParametricStudy:
                     dict[ColumnNames.RANDOM_SEED] = input.random_seed
                 num_added += 1
             else:
-                print(f"Invalid simulation input type: {type(input)}")
-                continue
+                raise TypeError(f"Invalid simulation input type: {type(input)}")
 
             dict[ColumnNames.ITERATION] = iteration
             dict[ColumnNames.PRIORITY] = priority

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -1394,56 +1394,35 @@ class ParametricStudy:
             # Drop duplicates and keep the latest completed simulation entry in case of adding a
             # completed simulation when using add_summaries.
             # Simulation status further narrows down subset of columns to check.
-            single_bead_df.drop_duplicates(
-                subset=sb_params + [ColumnNames.STATUS],
-                ignore_index=True,
-                keep="last",
-                inplace=True,
-            )
-            porosity_df.drop_duplicates(
-                subset=porosity_params + [ColumnNames.STATUS],
-                ignore_index=True,
-                keep="last",
-                inplace=True,
-            )
-            microstructure_df.drop_duplicates(
-                subset=microstructure_params + [ColumnNames.STATUS],
-                ignore_index=True,
-                keep="last",
-                inplace=True,
-            )
+
+            for df, params in zip(
+                [single_bead_df, porosity_df, microstructure_df],
+                [sb_params, porosity_params, microstructure_params],
+            ):
+                df.drop_duplicates(
+                    subset=params + [ColumnNames.STATUS],
+                    ignore_index=True,
+                    keep="last",
+                    inplace=True,
+                )
 
         # Drop duplicates and keep the earlier entry in case of adding a pending/skip simulation
         # when using add_inputs.
         # Completed simulations will remain as is since they are already sorted and are higher
         # up in the list.
-        if len(single_bead_df) > 0:
-            duplicates_removed_df = pd.concat(
-                [
-                    duplicates_removed_df,
-                    single_bead_df.drop_duplicates(
-                        subset=sb_params, ignore_index=True, keep="first"
-                    ),
-                ]
-            )
-        if len(porosity_df) > 0:
-            duplicates_removed_df = pd.concat(
-                [
-                    duplicates_removed_df,
-                    porosity_df.drop_duplicates(
-                        subset=porosity_params, ignore_index=True, keep="first"
-                    ),
-                ]
-            )
-        if len(microstructure_df) > 0:
-            duplicates_removed_df = pd.concat(
-                [
-                    duplicates_removed_df,
-                    microstructure_df.drop_duplicates(
-                        subset=microstructure_params, ignore_index=True, keep="first"
-                    ),
-                ]
-            )
+
+        for df, params in zip(
+            [single_bead_df, porosity_df, microstructure_df],
+            [sb_params, porosity_params, microstructure_params],
+        ):
+            if len(df) > 0:
+                duplicates_removed_df = pd.concat(
+                    [
+                        duplicates_removed_df,
+                        df.drop_duplicates(subset=params, ignore_index=True, keep="first"),
+                    ]
+                )
+
         self._data_frame = duplicates_removed_df
         if len(duplicates_removed_df) < len(current_df):
             LOG.debug(

--- a/tests/parametric_study/test_parametric_runner.py
+++ b/tests/parametric_study/test_parametric_runner.py
@@ -326,9 +326,9 @@ def test_simulate_filters_by_iteration(tmp_path: pytest.TempPathFactory):
     # arrange
     study = ps.ParametricStudy(tmp_path / "test_study")
     material = AdditiveMaterial(name="test_material")
-    sb1 = SingleBeadInput(id="iteration_1", material=material)
-    sb2 = SingleBeadInput(id="iteration_2", material=material)
-    sb3 = SingleBeadInput(id="iteration_3", material=material)
+    sb1 = SingleBeadInput(id="iteration_1", material=material, bead_length=0.001)
+    sb2 = SingleBeadInput(id="iteration_2", material=material, bead_length=0.002)
+    sb3 = SingleBeadInput(id="iteration_3", material=material, bead_length=0.003)
     study.add_inputs([sb1], iteration=1)
     study.add_inputs([sb2], iteration=2)
     study.add_inputs([sb3], iteration=3)

--- a/tests/parametric_study/test_parametric_study.py
+++ b/tests/parametric_study/test_parametric_study.py
@@ -1411,7 +1411,7 @@ def test_add_inputs_raises_error_with_simulation_status_completed_or_error(
     ]
 
     # act, assert
-    with pytest.raises(ValueError, match="Invalid simulation status"):
+    with pytest.raises(ValueError, match="Simulation status must be"):
         study.add_inputs(inputs, status=input_status)
 
 

--- a/tests/parametric_study/test_parametric_study.py
+++ b/tests/parametric_study/test_parametric_study.py
@@ -1166,7 +1166,7 @@ def test_add_inputs_creates_new_rows(tmp_path: pytest.TempPathFactory):
     assert len(df) == 3
 
 
-def test_add_inputs_does_not_create_new_rows_for_invalid_input(tmp_path: pytest.TempPathFactory):
+def test_add_inputs_raises_error_for_invalid_input(tmp_path: pytest.TempPathFactory):
     # arrange
     study = ps.ParametricStudy(tmp_path / "test_study")
     inputs = [
@@ -1174,12 +1174,9 @@ def test_add_inputs_does_not_create_new_rows_for_invalid_input(tmp_path: pytest.
         "another one",
     ]
 
-    # act
-    study.add_inputs(inputs)
-
-    # assert
-    df = study.data_frame()
-    assert len(df) == 0
+    # act, assert
+    with pytest.raises(TypeError, match="Invalid simulation input type"):
+        study.add_inputs(inputs, status=SimulationStatus.PENDING)
 
 
 def test_add_inputs_returns_correct_number_of_added_inputs(tmp_path: pytest.TempPathFactory):
@@ -1190,20 +1187,14 @@ def test_add_inputs_returns_correct_number_of_added_inputs(tmp_path: pytest.Temp
         PorosityInput(id="test_id_2"),
         MicrostructureInput(id="test_id_3"),
     ]
-    invalid_inputs = [
-        "invalid input",
-        "another one",
-    ]
 
     # act
     added = study.add_inputs(inputs)
     re_added = study.add_inputs(inputs)
-    invalid_added = study.add_inputs(invalid_inputs)
 
     # assert
     assert added == 3
     assert re_added == 0
-    assert invalid_added == 0
 
 
 def test_add_inputs_assigns_common_params_correctly(tmp_path: pytest.TempPathFactory):


### PR DESCRIPTION
closes #228 

- Add a method `_remove_duplicate_entries` that will remove or update any entries in the parametric study
- This method will return an integer specifying the number of duplicates removed
- This method will be called from `add_inputs` and `add_summaries`