### PR TITLE
Fix handling duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 * Fixed handling of material CSV files with alternative language settings (additiveserver) [#261](https://github.com/ansys/pyadditive/issues/261)
+* Duplicate simulations will be dropped from a parametric study [#290](https://github.com/ansys/pyadditive/issues/290)
 
 ### Doc Improvements
 * Updated parametric study examples to show importing a study from a csv file in [#259](https://github.com/ansys/pyadditive/pull/259/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-additive-core"
-version = "0.18.dev7"
+version = "0.18.dev8"
 description = "A Python client for the Ansys Additive service"
 readme = "README.rst"
 requires-python = ">=3.9,<4"

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -479,7 +479,7 @@ class ParametricStudy:
         max_area_energy_density: float | None = None,
         iteration: int = DEFAULT_ITERATION,
         priority: int = DEFAULT_PRIORITY,
-    ):
+    ) -> int:
         """Add single bead permutations to the parametric study.
 
         Parameters
@@ -524,6 +524,11 @@ class ParametricStudy:
             Iteration number for this set of simulations.
         priority : int, default: :obj:`DEFAULT_PRIORITY <constants.DEFAULT_PRIORITY>`
             Priority for this set of simulations.
+
+        Returns
+        -------
+        int
+            Number of single bead permutations added to the parametric study.
         """  # noqa: E501
         lt = (
             layer_thicknesses
@@ -542,6 +547,7 @@ class ParametricStudy:
         )
         min_aed = min_area_energy_density or 0.0
         max_aed = max_area_energy_density or float("inf")
+        num_permutations_added = int()
         for p in laser_powers:
             for v in scan_speeds:
                 for l in lt:
@@ -593,6 +599,8 @@ class ParametricStudy:
                             self._data_frame = pd.concat(
                                 [self._data_frame, row.to_frame().T], ignore_index=True
                             )
+                            num_permutations_added += 1
+        return num_permutations_added - self._remove_duplicate_entries(overwrite=False)
 
     @save_on_return
     def generate_porosity_permutations(
@@ -616,7 +624,7 @@ class ParametricStudy:
         max_build_rate: float | None = None,
         iteration: int = DEFAULT_ITERATION,
         priority: int = DEFAULT_PRIORITY,
-    ):
+    ) -> int:
         """Add porosity permutations to the parametric study.
 
         Parameters
@@ -702,6 +710,11 @@ class ParametricStudy:
             Iteration number for this set of simulations.
         priority : int, default: :obj:`DEFAULT_PRIORITY <constants.DEFAULT_PRIORITY>`
             Priority for this set of simulations.
+
+        Returns
+        -------
+        int
+            Number of porosity permutations added to the parametric study.
         """  # noqa: E501
         lt = (
             layer_thicknesses
@@ -742,6 +755,7 @@ class ParametricStudy:
         max_ed = max_energy_density or float("inf")
         min_br = min_build_rate or 0.0
         max_br = max_build_rate or float("inf")
+        num_permutations_added = int()
         for p in laser_powers:
             for v in scan_speeds:
                 for l in lt:
@@ -811,6 +825,8 @@ class ParametricStudy:
                                                 [self._data_frame, row.to_frame().T],
                                                 ignore_index=True,
                                             )
+                                            num_permutations_added += 1
+        return num_permutations_added - self._remove_duplicate_entries(overwrite=False)
 
     @save_on_return
     def generate_microstructure_permutations(
@@ -843,7 +859,7 @@ class ParametricStudy:
         random_seed: int | None = None,
         iteration: int = DEFAULT_ITERATION,
         priority: int = DEFAULT_PRIORITY,
-    ):
+    ) -> int:
         """Add microstructure permutations to the parametric study.
 
         Parameters
@@ -982,6 +998,11 @@ class ParametricStudy:
             Iteration number for this set of simulations.
         priority : int, default: :obj:`DEFAULT_PRIORITY <constants.DEFAULT_PRIORITY>`
             Priority for this set of simulations.
+
+        Returns
+        -------
+        int
+            Number of microstructure permutations added to the parametric study.
         """  # noqa
         lt = (
             layer_thicknesses
@@ -1036,6 +1057,7 @@ class ParametricStudy:
             melt_pool_width = melt_pool_width or MicrostructureInput.DEFAULT_MELT_POOL_WIDTH
             melt_pool_depth = melt_pool_depth or MicrostructureInput.DEFAULT_MELT_POOL_DEPTH
 
+        num_permutations_added = int()
         for p in laser_powers:
             for v in scan_speeds:
                 for l in lt:
@@ -1143,6 +1165,8 @@ class ParametricStudy:
                                                 [self._data_frame, row.to_frame().T],
                                                 ignore_index=True,
                                             )
+                                            num_permutations_added += 1
+        return num_permutations_added - self._remove_duplicate_entries(overwrite=False)
 
     @save_on_return
     def update(self, summaries: list[SingleBeadSummary | PorositySummary | MicrostructureSummary]):

--- a/tests/parametric_study/test_parametric_study.py
+++ b/tests/parametric_study/test_parametric_study.py
@@ -657,6 +657,44 @@ def test_generate_single_bead_permutations_only_adds_valid_permutations(
     assert df.loc[0, ps.ColumnNames.SCAN_SPEED] == MachineConstants.DEFAULT_SCAN_SPEED
 
 
+def test_generate_single_bead_permuations_returns_correct_number_of_simulations_added(
+    tmp_path: pytest.TempPathFactory,
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    bead_length = 0.005
+    powers = [50, 250, 700]
+    scan_speeds = [0.35, 1, 2.4]
+    layer_thicknesses = [30e-6, 50e-6]
+    heater_temperatures = [80, 100]
+    beam_diameters = [2e-5]
+
+    # act
+    initial_num_sim_added = study.generate_single_bead_permutations(
+        "material",
+        powers,
+        scan_speeds,
+        bead_length=bead_length,
+        layer_thicknesses=layer_thicknesses,
+        heater_temperatures=heater_temperatures,
+        beam_diameters=beam_diameters,
+    )
+
+    duplicate_num_sim_added = study.generate_single_bead_permutations(
+        "material",
+        powers,
+        scan_speeds,
+        bead_length=bead_length,
+        layer_thicknesses=layer_thicknesses,
+        heater_temperatures=heater_temperatures,
+        beam_diameters=beam_diameters,
+    )
+
+    # assert
+    assert initial_num_sim_added == 36
+    assert duplicate_num_sim_added == 0
+
+
 def test_generate_porosity_permutations_creates_permutations(tmp_path: pytest.TempPathFactory):
     # arrange
     study = ps.ParametricStudy(tmp_path / "test_study")
@@ -805,6 +843,62 @@ def test_generate_porosity_permutations_only_adds_valid_permutations(
     assert len(df) == 1
     assert df.loc[0, ps.ColumnNames.LASER_POWER] == MachineConstants.DEFAULT_LASER_POWER
     assert df.loc[0, ps.ColumnNames.SCAN_SPEED] == MachineConstants.DEFAULT_SCAN_SPEED
+
+
+def test_generate_porosity_permutations_returns_correct_number_of_simulations_added(
+    tmp_path: pytest.TempPathFactory,
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    powers = [50, 250, 700]
+    scan_speeds = [0.35, 1, 2.4]
+    layer_thicknesses = [30e-6, 50e-6]
+    heater_temperatures = [80, 100]
+    beam_diameters = [2e-5]
+    start_angles = [22.5, 0]
+    rotation_angles = [30]
+    hatch_spacings = [1e-4]
+    stripe_widths = [0.05]
+    size_x = 0.001
+    size_y = 0.002
+    size_z = 0.003
+
+    # act
+    initial_num_sim_added = study.generate_porosity_permutations(
+        "material",
+        powers,
+        scan_speeds,
+        size_x=size_x,
+        size_y=size_y,
+        size_z=size_z,
+        layer_thicknesses=layer_thicknesses,
+        heater_temperatures=heater_temperatures,
+        beam_diameters=beam_diameters,
+        start_angles=start_angles,
+        rotation_angles=rotation_angles,
+        hatch_spacings=hatch_spacings,
+        stripe_widths=stripe_widths,
+    )
+
+    duplicate_num_sim_added = study.generate_porosity_permutations(
+        "material",
+        powers,
+        scan_speeds,
+        size_x=size_x,
+        size_y=size_y,
+        size_z=size_z,
+        layer_thicknesses=layer_thicknesses,
+        heater_temperatures=heater_temperatures,
+        beam_diameters=beam_diameters,
+        start_angles=start_angles,
+        rotation_angles=rotation_angles,
+        hatch_spacings=hatch_spacings,
+        stripe_widths=stripe_widths,
+    )
+
+    # assert
+    assert initial_num_sim_added == 72
+    assert duplicate_num_sim_added == 0
 
 
 def test_generate_microstructure_permutations_creates_permutations(
@@ -1019,6 +1113,88 @@ def test_generate_microstructure_permutations_only_adds_valid_permutations(
     assert len(df) == 1
     assert df.loc[0, ps.ColumnNames.LASER_POWER] == MachineConstants.DEFAULT_LASER_POWER
     assert df.loc[0, ps.ColumnNames.SCAN_SPEED] == MachineConstants.DEFAULT_SCAN_SPEED
+
+
+def test_generate_microstructure_permutations_returns_correct_number_of_simulations_added(
+    tmp_path: pytest.TempPathFactory,
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    powers = [50, 250, 700]
+    scan_speeds = [0.35, 1, 2.4]
+    layer_thicknesses = [30e-6, 50e-6]
+    heater_temperatures = [80, 100]
+    beam_diameters = [2e-5]
+    start_angles = [22.5, 0]
+    rotation_angles = [30]
+    hatch_spacings = [1e-4]
+    stripe_widths = [0.05]
+    min_x = 1
+    min_y = 2
+    min_z = 3
+    size_x = 0.001
+    size_y = 0.002
+    size_z = 0.003
+    cooling_rate = MicrostructureInput.DEFAULT_COOLING_RATE
+    thermal_gradient = MicrostructureInput.DEFAULT_THERMAL_GRADIENT
+    melt_pool_width = MicrostructureInput.DEFAULT_MELT_POOL_WIDTH
+    melt_pool_depth = MicrostructureInput.DEFAULT_MELT_POOL_DEPTH
+    random_seed = 1234
+
+    # act
+    initial_num_sim_added = study.generate_microstructure_permutations(
+        "material",
+        powers,
+        scan_speeds,
+        min_x=min_x,
+        min_y=min_y,
+        min_z=min_z,
+        size_x=size_x,
+        size_y=size_y,
+        size_z=size_z,
+        layer_thicknesses=layer_thicknesses,
+        heater_temperatures=heater_temperatures,
+        beam_diameters=beam_diameters,
+        start_angles=start_angles,
+        rotation_angles=rotation_angles,
+        hatch_spacings=hatch_spacings,
+        stripe_widths=stripe_widths,
+        cooling_rate=cooling_rate,
+        thermal_gradient=thermal_gradient,
+        melt_pool_width=melt_pool_width,
+        melt_pool_depth=melt_pool_depth,
+        random_seed=random_seed,
+        iteration=9,
+    )
+
+    duplicate_num_sim_added = study.generate_microstructure_permutations(
+        "material",
+        powers,
+        scan_speeds,
+        min_x=min_x,
+        min_y=min_y,
+        min_z=min_z,
+        size_x=size_x,
+        size_y=size_y,
+        size_z=size_z,
+        layer_thicknesses=layer_thicknesses,
+        heater_temperatures=heater_temperatures,
+        beam_diameters=beam_diameters,
+        start_angles=start_angles,
+        rotation_angles=rotation_angles,
+        hatch_spacings=hatch_spacings,
+        stripe_widths=stripe_widths,
+        cooling_rate=cooling_rate,
+        thermal_gradient=thermal_gradient,
+        melt_pool_width=melt_pool_width,
+        melt_pool_depth=melt_pool_depth,
+        random_seed=random_seed,
+        iteration=9,
+    )
+
+    # assert
+    assert initial_num_sim_added == 72
+    assert duplicate_num_sim_added == 0
 
 
 def test_update_updates_error_status(tmp_path: pytest.TempPathFactory):
@@ -1405,6 +1581,27 @@ def test_add_inputs_raises_error_with_simulation_status_completed_or_error(
     # act, assert
     with pytest.raises(ValueError, match="Simulation status must be"):
         study.add_inputs(inputs, status=input_status)
+
+
+def test_add_inputs_returns_correct_number_of_simulations_added_to_the_study(
+    tmp_path: pytest.TempPathFactory,
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    inputs = [
+        SingleBeadInput(id="test_id_1"),
+        PorosityInput(id="test_id_2"),
+        MicrostructureInput(id="test_id_3"),
+        SingleBeadInput(id="test_id_1"),
+        PorosityInput(id="test_id_2"),
+        MicrostructureInput(id="test_id_3"),
+    ]
+
+    # act
+    added = study.add_inputs(inputs, status=SimulationStatus.PENDING)
+
+    # assert
+    assert added == 3
 
 
 @pytest.mark.parametrize("input_status", [(SimulationStatus.PENDING), (SimulationStatus.SKIP)])


### PR DESCRIPTION
closes #290 

With this PR - 
- the method `_remove_duplicate_entries` will be called for each of the `generate_<simtype>_permutations(*)` so that any duplicate entries are dropped. 
- the methods `generate_<simtype>_permutations(*)` will now return an int specifying the number of permutations that were added to the parametric study. 
- the assumption taken into account is that if simulations are added to any existing parametric study, the study does not contain any duplicate simulations to begin with. 