### PR TITLE
Add single bead thermal history parameters

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -8,6 +8,7 @@ on:
       - "*"
     branches:
       - main
+      - feat/single-bead-thermal-history
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Updated parametric study to check for duplicate entries [#228](https://github.com/ansys/pyadditive/issues/228)
 * Added 3D microstructure (BETA) simulations [#276](https://github.com/ansys/pyadditive/issues/276)
 * Increased max random seed limit for microstructure simulations [#325](https://github.com/ansys/pyadditive/pull/325/files)
+* Add single bead thermal history parameters
 
 ### Bug Fixes
 * Removed side effect from `ParametricStudy.save()` which changed the study file path if the `file_name` parameter differed from the `ParameticStudy.file_name` property. Also removed the `save_file_name` parameter from `ParametricStudy.load()`. [#301](https://github.com/ansys/pyadditive/issues/301)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-additive-core"
-version = "0.18.dev14"
+version = "0.18.dev15"
 description = "A Python client for the Ansys Additive service"
 readme = "README.rst"
 requires-python = ">=3.9,<4"

--- a/tests/test_single_bead.py
+++ b/tests/test_single_bead.py
@@ -187,6 +187,8 @@ def test_SingleBeadInput_repr_creates_expected_string():
         + "vaporization_temperature: 0\n"
         + "characteristic_width_data: CharacteristicWidthDataPoint[]\n"
         + "thermal_properties_data: ThermalPropertiesDataPoint[]\n"
+        + "output_thermal_history: False\n"
+        + "thermal_history_interval: 1\n"
     )
 
 
@@ -300,6 +302,8 @@ def test_SingleBeadSummary_repr_returns_expected_string():
         + "vaporization_temperature: 0\n"
         + "characteristic_width_data: CharacteristicWidthDataPoint[]\n"
         + "thermal_properties_data: ThermalPropertiesDataPoint[]\n"
+        + "output_thermal_history: False\n"
+        + "thermal_history_interval: 1\n"
         + "\n"
         + "melt_pool: MeltPool\n"
         + "Empty DataFrame\nColumns: [length, width, depth, reference_width, reference_depth]\nIndex: []"


### PR DESCRIPTION
- Update `single_bead.py` to include the parameters
- Update 'test_single_bead.py` for `__repr__` change
- Update `ci_cd.yaml` to trigger runs

@Todo 
- Add more tests to verify the new arg values for the `SingleBeadInput` class constructor.
- Update the example to show the thermal history for single bead