### PR TITLE
Update parametric runner to accept a list of simulation ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### New Features
 * Default version of Additive Server is 25.1 when creating a client connection.
 * Single bead simulations with thermal history are now supported.
-* Added description field to AdditiveMaterial
+* Added description field to AdditiveMaterial.
+* Updated the parametric runner to accept a list of simulation ids to be run.
 
 ### Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-additive-core"
-version = "0.19.dev9"
+version = "0.19.dev10"
 description = "A Python client for the Ansys Additive service"
 readme = "README.rst"
 requires-python = ">=3.9,<4"

--- a/src/ansys/additive/core/parametric_study/parametric_runner.py
+++ b/src/ansys/additive/core/parametric_study/parametric_runner.py
@@ -102,7 +102,7 @@ class ParametricRunner:
             simulation_ids_list = list()
             for sim_id in simulation_ids:
                 if sim_id not in view[ColumnNames.ID].values:
-                    LOG.debug(f"Simulation ID '{sim_id}' not found in the parametric study")
+                    LOG.warning(f"Simulation ID '{sim_id}' not found in the parametric study")
                 elif sim_id in simulation_ids_list:
                     LOG.debug(f"Simulation ID '{sim_id}' has already been added")
                 else:

--- a/src/ansys/additive/core/parametric_study/parametric_runner.py
+++ b/src/ansys/additive/core/parametric_study/parametric_runner.py
@@ -50,6 +50,7 @@ class ParametricRunner:
     def simulate(
         df: pd.DataFrame,
         additive: Additive,
+        simulation_ids: list[str] = None,
         type: list[SimulationType] = None,
         priority: int = None,
         iteration: int = None,
@@ -65,6 +66,10 @@ class ParametricRunner:
             Parametric study data frame.
         additive : Additive
             Additive service connection to use for running simulations.
+        simulation_ids: list[str], default: None
+            List of simulation IDs to run. The default is ``None``, in which case
+            all simulations in the parametric study are run. Any other filtering criteria
+            if provided, are applied on this list.
         type : list, default: None
             List of the simulation types to run. The default is ``None``, in which case all
             simulation types are run.
@@ -92,6 +97,18 @@ class ParametricRunner:
         view = df[
             (df[ColumnNames.STATUS] == SimulationStatus.PENDING) & df[ColumnNames.TYPE].isin(type)
         ]
+
+        if isinstance(simulation_ids, list) and len(simulation_ids) > 0:
+            simulation_ids_list = list()
+            for sim_id in simulation_ids:
+                if sim_id not in view[ColumnNames.ID].values:
+                    LOG.warning(f"Simulation ID '{sim_id}' not found in the parametric study")
+                elif sim_id in simulation_ids_list:
+                    LOG.warning(f"Simulation ID '{sim_id}' has already been added")
+                else:
+                    simulation_ids_list.append(sim_id)
+            view = df[df[ColumnNames.ID].isin(simulation_ids_list)]
+
         if priority is not None:
             view = view[view[ColumnNames.PRIORITY] == priority]
         view = view.sort_values(by=ColumnNames.PRIORITY, ascending=True)

--- a/src/ansys/additive/core/parametric_study/parametric_runner.py
+++ b/src/ansys/additive/core/parametric_study/parametric_runner.py
@@ -102,12 +102,12 @@ class ParametricRunner:
             simulation_ids_list = list()
             for sim_id in simulation_ids:
                 if sim_id not in view[ColumnNames.ID].values:
-                    LOG.warning(f"Simulation ID '{sim_id}' not found in the parametric study")
+                    LOG.debug(f"Simulation ID '{sim_id}' not found in the parametric study")
                 elif sim_id in simulation_ids_list:
-                    LOG.warning(f"Simulation ID '{sim_id}' has already been added")
+                    LOG.debug(f"Simulation ID '{sim_id}' has already been added")
                 else:
                     simulation_ids_list.append(sim_id)
-            view = df[df[ColumnNames.ID].isin(simulation_ids_list)]
+            view = view[view[ColumnNames.ID].isin(simulation_ids_list)]
 
         if priority is not None:
             view = view[view[ColumnNames.PRIORITY] == priority]

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -192,7 +192,7 @@ class ParametricStudy:
             Additive service connection to use for running simulations.
         simulation_ids : list[str], default: None
             List of simulation IDs to run. If this value is ``None``,
-            all simulations are run.
+            all simulations with a status of ``Pending`` are run.
         type : list[SimulationType], default: None
             Type of simulations to run. If this value is ``None``,
             all simulation types are run.

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -175,6 +175,7 @@ class ParametricStudy:
     def run_simulations(
         self,
         additive: Additive,
+        simulation_ids: list[str] | None = None,
         type: list[SimulationType] | None = None,
         priority: int | None = None,
         iteration: int = None,
@@ -189,6 +190,9 @@ class ParametricStudy:
         ----------
         additive : Additive
             Additive service connection to use for running simulations.
+        simulation_ids : list[str], default: None
+            List of simulation IDs to run. If this value is ``None``,
+            all simulations are run.
         type : list[SimulationType], default: None
             Type of simulations to run. If this value is ``None``,
             all simulation types are run.
@@ -202,6 +206,7 @@ class ParametricStudy:
         summaries = ParametricRunner.simulate(
             self.data_frame(),
             additive,
+            simulation_ids=simulation_ids,
             type=type,
             priority=priority,
             iteration=iteration,

--- a/tests/parametric_study/test_parametric_runner.py
+++ b/tests/parametric_study/test_parametric_runner.py
@@ -431,3 +431,194 @@ def test_simulate_returns_empty_list_when_no_simulations_meet_criteria(
     for record in caplog.records:
         assert record.levelname == "WARNING"
         assert "None of the input simulations meet the criteria selected" in record.message
+
+
+@pytest.mark.parametrize(
+    "simulation_ids_input",
+    [
+        ["test_2"],
+        ["test_0", "test_2"],
+    ],
+)
+def test_simulate_filters_by_simulation_ids_if_the_list_has_atleast_one_valid_element(
+    simulation_ids_input, tmp_path: pytest.TempPathFactory
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    material = AdditiveMaterial(name="test_material")
+    sb = SingleBeadInput(id="test_1", material=material)
+    p = PorosityInput(id="test_2", material=material)
+    ms = MicrostructureInput(id="test_3", material=material)
+    study.add_inputs([sb], priority=1)
+    study.add_inputs([p], priority=2)
+    study.add_inputs([ms], priority=3)
+    inputs = [p]
+    mock_additive = create_autospec(Additive)
+    mock_additive.material.return_value = material
+
+    # act
+    pr.simulate(study.data_frame(), mock_additive, simulation_ids=simulation_ids_input)
+
+    # assert
+    mock_additive.simulate.assert_called_once_with(inputs)
+
+
+@pytest.mark.parametrize(
+    "simulation_ids_input",
+    [
+        [],
+        None,
+    ],
+)
+def test_simulate_skips_filter_by_simulation_ids_if_the_list_is_empty_or_none(
+    simulation_ids_input, tmp_path: pytest.TempPathFactory
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    material = AdditiveMaterial(name="test_material")
+    sb = SingleBeadInput(id="test_1", material=material)
+    p = PorosityInput(id="test_2", material=material)
+    ms = MicrostructureInput(id="test_3", material=material)
+    study.add_inputs([sb], priority=1)
+    study.add_inputs([p], priority=2)
+    study.add_inputs([ms], priority=3)
+    inputs = [sb, p, ms]
+    mock_additive = create_autospec(Additive)
+    mock_additive.material.return_value = material
+
+    # act
+    pr.simulate(study.data_frame(), mock_additive, simulation_ids=simulation_ids_input)
+
+    # assert
+    mock_additive.simulate.assert_called_once_with(inputs)
+
+
+def test_simulate_is_skipped_if_simulation_ids_list_has_invalid_elements(
+    tmp_path: pytest.TempPathFactory, caplog
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    material = AdditiveMaterial(name="test_material")
+    sb = SingleBeadInput(id="test_1", material=material)
+    p = PorosityInput(id="test_2", material=material)
+    ms = MicrostructureInput(id="test_3", material=material)
+    study.add_inputs([sb], priority=1)
+    study.add_inputs([p], priority=2)
+    study.add_inputs([ms], priority=3)
+    mock_additive = create_autospec(Additive)
+    mock_additive.material.return_value = material
+
+    # act
+    result = pr.simulate(study.data_frame(), mock_additive, simulation_ids=["test_0", "test_4"])
+
+    # assert
+    mock_additive.simulate.assert_not_called()
+    assert result == []
+    assert len(caplog.records) == 3
+    for record in caplog.records:
+        assert record.levelname == "WARNING"
+    assert "Simulation ID 'test_0' not found in the parametric study" in caplog.records[0].message
+    assert "Simulation ID 'test_4' not found in the parametric study" in caplog.records[1].message
+    assert "None of the input simulations meet the criteria selected" in caplog.records[2].message
+
+
+def test_simulate_filters_by_simulation_ids_and_skips_duplicates(
+    tmp_path: pytest.TempPathFactory, caplog
+):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    material = AdditiveMaterial(name="test_material")
+    sb = SingleBeadInput(id="test_1", material=material)
+    p = PorosityInput(id="test_2", material=material)
+    ms = MicrostructureInput(id="test_3", material=material)
+    study.add_inputs([sb], priority=1)
+    study.add_inputs([p], priority=2)
+    study.add_inputs([ms], priority=3)
+    inputs = [sb, p]
+    mock_additive = create_autospec(Additive)
+    mock_additive.material.return_value = material
+
+    # act
+    pr.simulate(study.data_frame(), mock_additive, simulation_ids=["test_1", "test_2", "test_1"])
+
+    # assert
+    mock_additive.simulate.assert_called_once_with(inputs)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "Simulation ID 'test_1' has already been added" in caplog.records[0].message
+
+
+def test_simulate_filters_by_simulation_ids_and_sorts_by_priority(tmp_path: pytest.TempPathFactory):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    material = AdditiveMaterial(name="test_material")
+    sb = SingleBeadInput(id="test_1", material=material)
+    p = PorosityInput(id="test_2", material=material)
+    ms = MicrostructureInput(id="test_3", material=material)
+    study.add_inputs([sb], priority=1)
+    study.add_inputs([p], priority=2)
+    study.add_inputs([ms], priority=3)
+    inputs = [sb, ms]  # note that pr.simulate should reorder the inputs based on the priority
+    mock_additive = create_autospec(Additive)
+    mock_additive.material.return_value = material
+
+    # act
+    pr.simulate(study.data_frame(), mock_additive, simulation_ids=["test_3", "test_1"])
+
+    # assert
+    mock_additive.simulate.assert_called_once_with(inputs)
+
+
+def test_simulate_filters_by_simulation_ids_and_iteration(tmp_path: pytest.TempPathFactory):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    material = AdditiveMaterial(name="test_material")
+    sb = SingleBeadInput(id="test_1", material=material)
+    p = PorosityInput(id="test_2", material=material)
+    ms = MicrostructureInput(id="test_3", material=material)
+    study.add_inputs([sb], iteration=1)
+    study.add_inputs([p], iteration=2)
+    study.add_inputs([ms], iteration=3)
+    inputs = [sb]
+    mock_additive = create_autospec(Additive)
+    mock_additive.material.return_value = material
+
+    # act
+    pr.simulate(
+        study.data_frame(),
+        mock_additive,
+        simulation_ids=["test_3", "test_2", "test_1"],
+        iteration=1,
+    )
+
+    # assert
+    mock_additive.simulate.assert_called_once_with(inputs)
+
+
+def test_simulate_filters_by_simulation_ids_and_type(tmp_path: pytest.TempPathFactory):
+    # arrange
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    material = AdditiveMaterial(name="test_material")
+    sb_1 = SingleBeadInput(bead_length=0.001, id="test_1", material=material)
+    sb_2 = SingleBeadInput(bead_length=0.002, id="test_2", material=material)
+    sb_3 = SingleBeadInput(bead_length=0.003, id="test_3", material=material)
+    sb_4 = SingleBeadInput(bead_length=0.004, id="test_4", material=material)
+    p = PorosityInput(id="test_5", material=material)
+    ms = MicrostructureInput(id="test_6", material=material)
+    study.add_inputs([sb_1, sb_2, sb_3, sb_4], iteration=1)
+    study.add_inputs([p], iteration=2)
+    study.add_inputs([ms], iteration=3)
+    inputs = [sb_1, sb_2]
+    mock_additive = create_autospec(Additive)
+    mock_additive.material.return_value = material
+
+    # act
+    pr.simulate(
+        study.data_frame(),
+        mock_additive,
+        simulation_ids=["test_1", "test_2", "test_5", "test_6"],
+        type=SimulationType.SINGLE_BEAD,
+    )
+
+    # assert
+    mock_additive.simulate.assert_called_once_with(inputs)

--- a/tests/parametric_study/test_parametric_study.py
+++ b/tests/parametric_study/test_parametric_study.py
@@ -1815,6 +1815,28 @@ def test_run_simulations_with_iteration_calls_simulate_correctly(
     assert patched_simulate.call_args[1]["iteration"] == 2
 
 
+def test_rum_simulations_with_simulation_ids_calls_simulate_correctly(
+    monkeypatch, tmp_path: pytest.TempPathFactory
+):
+    study = ps.ParametricStudy(tmp_path / "test_study")
+    sb1 = SingleBeadInput(id="test_1", bead_length=0.001)
+    sb2 = SingleBeadInput(id="test_2", bead_length=0.002)
+    sb3 = SingleBeadInput(id="test_3", bead_length=0.003)
+    study.add_inputs([sb1])
+    study.add_inputs([sb2])
+    study.add_inputs([sb3])
+    mock_additive = create_autospec(Additive)
+    # mock_additive.material.return_value = material
+    patched_simulate = create_autospec(ParametricRunner.simulate, return_value=[])
+    monkeypatch.setattr(ParametricRunner, "simulate", patched_simulate)
+
+    # act
+    study.run_simulations(mock_additive, simulation_ids=["test_3"])
+
+    # assert
+    assert patched_simulate.call_args[1]["simulation_ids"] == ["test_3"]
+
+
 def test_remove_deletes_multiple_rows_from_dataframe(tmp_path: pytest.TempPathFactory):
     # arrange
     study = ps.ParametricStudy(tmp_path / "test_study")


### PR DESCRIPTION
- Update the method `ParametricRunner.simulate` to accept an argument `simulation_ids` of type `list[str]` 
- This argument will contain a list of simulation ids and the method will first filter the parametric study to only run the provided simulation ids.
- Note that if the list is empty or the default `None` value, no simulations will be filtered. All simulations will be run. 
- Any other arguments like `priority, iteration` and `type` will be applied over the filtered simulations. 
- Unit tests are updated to include this argument with valid, invalid, empty, null, and duplicate simulation ids. Some more tests cover this argument in combination with others. 