### PR TITLE
use pv-ratio in studies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 * ParametricStudy.set_status() and ParametricStudy.reset_status() have been renamed to ParametricStudy.set_simulation_status() and ParametricStudy.reset_simulation_status().
 * ParametricStudy() now requires a material name parameter. As a consequence, the material_name parameter has been removed from ParametricStudy.generate_single_bead_permutations(), ParametricStudy.generate_porosity_permutations(), and ParametricStudy.generate_microstructure_permutations(). The parametric study FORMAT_VERSION value has been incremented to 3.
 * The ParametricRunner class has been removed. To run a parametric study, use Additive.simulate_study() or Additive.simulate_study_async().
-* The ParametricStudy.generate_single_bead_permutations() will now accept min and max p/v ratio constraint instead
-of min and max area energy density.
+* The ParametricStudy.generate_single_bead_permutations() will now accept min and max p/v ratios as constraints instead of min and max area energy densities.
 
 ### New Features
 * Default version of Additive Server is 25.1 when creating a client connection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * ParametricStudy.set_status() and ParametricStudy.reset_status() have been renamed to ParametricStudy.set_simulation_status() and ParametricStudy.reset_simulation_status().
 * ParametricStudy() now requires a material name parameter. As a consequence, the material_name parameter has been removed from ParametricStudy.generate_single_bead_permutations(), ParametricStudy.generate_porosity_permutations(), and ParametricStudy.generate_microstructure_permutations(). The parametric study FORMAT_VERSION value has been incremented to 3.
 * The ParametricRunner class has been removed. To run a parametric study, use Additive.simulate_study() or Additive.simulate_study_async().
+* The ParametricStudy.generate_single_bead_permutations() will now accept min and max p/v ratio constraint instead
+of min and max area energy density.
 
 ### New Features
 * Default version of Additive Server is 25.1 when creating a client connection.
@@ -18,6 +20,7 @@
 * Added apply and list server settings functionality.
 * Parametric study data is updated as simulations are running.
 * Use LOG for logging in Additive object.
+* A new column for the P/V Ratio (Laser Power / Laser Scan Speed) is added to the study.
 
 ### Bug Fixes
 

--- a/examples/11_advanced_parametric_study.py
+++ b/examples/11_advanced_parametric_study.py
@@ -83,7 +83,7 @@ print(study.file_name)
 # :meth:`~ParametricStudy.generate_single_bead_permutations` method is used to
 # generate single bead simulation permutations. The parameters
 # for the :meth:`~ParametricStudy.generate_single_bead_permutations` method allow you to
-# specify a range of machine parameters and filter them by energy density. Not all
+# specify a range of machine parameters and filter them by the P/V ratio. Not all
 # the parameters shown are required. Optional parameters that are not specified
 # use default values defined in the :class:`MachineConstants` class.
 
@@ -97,8 +97,8 @@ initial_layer_thicknesses = [40e-6, 50e-6]
 initial_beam_diameters = [80e-6]
 # Specify heater temperatures. Valid values are 20 - 500 C.
 initial_heater_temps = [80]
-# Restrict the permutations within a range of energy densities
-# For single bead, the pv ratio is laser power / laser scan speed.
+# Restrict the permutations within a range of P/V ratios. The P is for laser power
+# and the V is for velocity, which is the laser scan speed.
 min_pv_ratio = 80
 max_pv_ratio = 400
 # Specify a bead length in meters.

--- a/examples/11_advanced_parametric_study.py
+++ b/examples/11_advanced_parametric_study.py
@@ -98,9 +98,9 @@ initial_beam_diameters = [80e-6]
 # Specify heater temperatures. Valid values are 20 - 500 C.
 initial_heater_temps = [80]
 # Restrict the permutations within a range of energy densities
-# For single bead, the energy density is laser power / (laser scan speed * layer thickness).
-min_energy_density = 2e6
-max_energy_density = 8e6
+# For single bead, the pv ratio is laser power / laser scan speed.
+min_pv_ratio = 80
+max_pv_ratio = 400
 # Specify a bead length in meters.
 bead_length = 0.001
 
@@ -111,8 +111,8 @@ study.generate_single_bead_permutations(
     layer_thicknesses=initial_layer_thicknesses,
     beam_diameters=initial_beam_diameters,
     heater_temperatures=initial_heater_temps,
-    min_area_energy_density=min_energy_density,
-    max_area_energy_density=max_energy_density,
+    min_pv_ratio=min_pv_ratio,
+    max_pv_ratio=max_pv_ratio,
 )
 
 ###############################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-additive-core"
-version = "0.19.dev25"
+version = "0.19.dev27"
 description = "A Python client for the Ansys Additive service"
 readme = "README.rst"
 requires-python = ">=3.10,<4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ tests = [
     "six==1.16.0",
     "tqdm==4.66.5",
     "pydantic==2.9.2",
-    "pytest==8.3.2",
+    "pytest==8.3.3",
     "pytest-cov==5.0.0",
 ]
 

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -465,11 +465,11 @@ class ParametricStudy:
             is used. Valid values are from :obj:`MIN_BEAM_DIAMETER <MachineConstants.MIN_BEAM_DIAMETER>`
             to :obj:`MAX_BEAM_DIAMETER <MachineConstants.MAX_BEAM_DIAMETER>`.
         min_pv_ratio : float, default: None
-            For p/v ratio, the p refers to the laser power (W) and v refers to the velocity of the laser beam
-            which is the scan speed (m/s). Parameter combinations with a ratio below this value are not included.
+            The P/V ratio is defined as the ratio of laser power (w) to the velocity of the laser beam, which
+            is the scan speed (m/s). Parameter combinations with ratios less than this value are not included.
         max_pv_ratio : float, default: None
-            For p/v ratio, the p refers to the laser power (W) and v refers to the velocity of the laser beam
-            which is the scan speed (m/s). Parameter combinations with a ratio above this value are not included.
+            The P/V ratio is defined as the ratio of laser power (w) to the velocity of the laser beam, which
+            is the scan speed (m/s). Parameter combinations with ratios greater than this value are not included.
         iteration : int, default: :obj:`DEFAULT_ITERATION <constants.DEFAULT_ITERATION>`
             Iteration number for this set of simulations.
         priority : int, default: :obj:`DEFAULT_PRIORITY <constants.DEFAULT_PRIORITY>`

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -465,11 +465,11 @@ class ParametricStudy:
             is used. Valid values are from :obj:`MIN_BEAM_DIAMETER <MachineConstants.MIN_BEAM_DIAMETER>`
             to :obj:`MAX_BEAM_DIAMETER <MachineConstants.MAX_BEAM_DIAMETER>`.
         min_pv_ratio : float, default: None
-            Minimum laser power to scan speed ratio (J/m) to use for single bead simulations.
-            Parameter combinations with a ratio below this value are not included.
+            For p/v ratio, the p refers to the laser power (W) and v refers to the velocity of the laser beam
+            which is the scan speed (m/s). Parameter combinations with a ratio below this value are not included.
         max_pv_ratio : float, default: None
-            Maximum laser power to scan speed ratio (J/m) to use for single bead simulations.
-            Parameter combinations with a ratio above this value are not included.
+            For p/v ratio, the p refers to the laser power (W) and v refers to the velocity of the laser beam
+            which is the scan speed (m/s). Parameter combinations with a ratio above this value are not included.
         iteration : int, default: :obj:`DEFAULT_ITERATION <constants.DEFAULT_ITERATION>`
             Iteration number for this set of simulations.
         priority : int, default: :obj:`DEFAULT_PRIORITY <constants.DEFAULT_PRIORITY>`

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -293,18 +293,12 @@ class ParametricStudy:
         self, summary: SingleBeadSummary, iteration: int = DEFAULT_ITERATION
     ):
         mp = summary.melt_pool
-        br = build_rate(summary.input.machine.scan_speed, summary.input.machine.layer_thickness)
-        ed = energy_density(
-            summary.input.machine.laser_power,
-            summary.input.machine.scan_speed,
-            summary.input.machine.layer_thickness,
-        )
         row = pd.Series(
             {
                 **self._common_param_to_dict(summary, iteration),
                 ColumnNames.TYPE: SimulationType.SINGLE_BEAD,
-                ColumnNames.BUILD_RATE: br,
-                ColumnNames.ENERGY_DENSITY: ed,
+                ColumnNames.BUILD_RATE: None,
+                ColumnNames.ENERGY_DENSITY: None,
                 ColumnNames.SINGLE_BEAD_LENGTH: summary.input.bead_length,
                 ColumnNames.MELT_POOL_WIDTH: mp.median_width(),
                 ColumnNames.MELT_POOL_DEPTH: mp.median_depth(),
@@ -435,8 +429,8 @@ class ParametricStudy:
         layer_thicknesses: list[float] | None = None,
         heater_temperatures: list[float] | None = None,
         beam_diameters: list[float] | None = None,
-        min_area_energy_density: float | None = None,
-        max_area_energy_density: float | None = None,
+        min_pv_ratio: float | None = None,
+        max_pv_ratio: float | None = None,
         iteration: int = DEFAULT_ITERATION,
         priority: int = DEFAULT_PRIORITY,
     ) -> int:
@@ -470,14 +464,12 @@ class ParametricStudy:
             If this value is ``None``, :obj:`DEFAULT_BEAM_DIAMETER <MachineConstants.DEFAULT_BEAM_DIAMETER>`
             is used. Valid values are from :obj:`MIN_BEAM_DIAMETER <MachineConstants.MIN_BEAM_DIAMETER>`
             to :obj:`MAX_BEAM_DIAMETER <MachineConstants.MAX_BEAM_DIAMETER>`.
-        min_area_energy_density : float, default: None
-            Minimum area energy density (J/m^2) to use for single bead simulations.
-            Parameter combinations with an area energy density below this value are
-            not included. Area energy density is defined as laser power / (layer thickness * scan speed).
-        max_area_energy_density : float, default: None
-            Maximum area energy density (J/m^2) to use for single bead simulations.
-            Parameter combinations with an area energy density above this value are
-            not included. Area energy density is defined as laser power / (layer thickness * scan speed).
+        min_pv_ratio : float, default: None
+            Minimum laser power to scan speed ratio (J/m) to use for single bead simulations.
+            Parameter combinations with a ratio below this value are not included.
+        max_pv_ratio : float, default: None
+            Maximum laser power to scan speed ratio (J/m) to use for single bead simulations.
+            Parameter combinations with a ratio above this value are not included.
         iteration : int, default: :obj:`DEFAULT_ITERATION <constants.DEFAULT_ITERATION>`
             Iteration number for this set of simulations.
         priority : int, default: :obj:`DEFAULT_PRIORITY <constants.DEFAULT_PRIORITY>`
@@ -503,14 +495,14 @@ class ParametricStudy:
             if heater_temperatures is not None
             else [MachineConstants.DEFAULT_HEATER_TEMP]
         )
-        min_aed = min_area_energy_density or 0.0
-        max_aed = max_area_energy_density or float("inf")
+        min_pv = min_pv_ratio or 0.0
+        max_pv = max_pv_ratio or float("inf")
         num_permutations_added = int()
         for p in laser_powers:
             for v in scan_speeds:
                 for l in lt:
-                    aed = energy_density(p, v, l)
-                    if aed < min_aed or aed > max_aed:
+                    pv_ratio = p / v
+                    if pv_ratio < min_pv or pv_ratio > max_pv:
                         continue
 
                     for t in ht:
@@ -550,8 +542,8 @@ class ParametricStudy:
                                     ColumnNames.LASER_POWER: p,
                                     ColumnNames.SCAN_SPEED: v,
                                     ColumnNames.PV_RATIO: p / v,
-                                    ColumnNames.ENERGY_DENSITY: aed,
-                                    ColumnNames.BUILD_RATE: build_rate(v, l),
+                                    ColumnNames.ENERGY_DENSITY: None,
+                                    ColumnNames.BUILD_RATE: None,
                                     ColumnNames.SINGLE_BEAD_LENGTH: bead_length,
                                 }
                             )
@@ -647,13 +639,13 @@ class ParametricStudy:
             is used. Valid values are from :obj:`MIN_SLICING_STRIPE_WIDTH <MachineConstants.MIN_SLICING_STRIPE_WIDTH>`
             to :obj:`MAX_SLICING_STRIPE_WIDTH <MachineConstants.MAX_SLICING_STRIPE_WIDTH>`.
         min_energy_density : float, default: None
-            Minimum energy density (J/m^3) to use for porosity simulations. Parameter combinations
-            with an area energy density below this value are not included. Area energy density is
+            Minimum energy density (J/m^3) to use for porosity simulations. Energy density is
             defined as laser power / (layer thickness * scan speed * hatch spacing).
+            Parameter combinations with an energy density below this value are not included.
         max_energy_density : float, default: None
-            Maximum energy density (J/m^3) to use for porosity simulations. Parameter combinations
-            with an area energy density above this value are not included. Energy density is defined
-            as laser power / (layer thickness * scan speed * hatch spacing).
+            Maximum energy density (J/m^3) to use for porosity simulations. Energy density is
+            defined as laser power / (layer thickness * scan speed * hatch spacing).
+            Parameter combinations with an energy density above this value are not included.
         min_build_rate : float, default: None
             Minimum build rate (m^3/s) to use for porosity simulations. Parameter combinations
             with a build rate below this value are not included. Build rate is defined as
@@ -900,13 +892,13 @@ class ParametricStudy:
             is used. Valid values are from :obj:`MIN_SLICING_STRIPE_WIDTH <MachineConstants.MIN_SLICING_STRIPE_WIDTH>`
             to :obj:`MAX_SLICING_STRIPE_WIDTH <MachineConstants.MAX_SLICING_STRIPE_WIDTH>`.
         min_energy_density : float, default: None
-            Minimum energy density (J/m^3) to use for microstructure simulations.
-            Parameter combinations with an area energy density below this value are not included.
-            Area energy density is defined as laser power / (layer thickness * scan speed * hatch spacing).
+            Minimum energy density (J/m^3) to use for microstructure simulations. Energy density is
+            defined as laser power / (layer thickness * scan speed * hatch spacing).
+            Parameter combinations with an energy density below this value are not included.
         max_energy_density : float, default: None
-            The maximum energy density (J/m^3) to use for microstructure simulations.
-            Parameter combinations with an area energy density above this value will not be included.
-            Energy density is defined as laser power / (layer thickness * scan speed * hatch spacing).
+            Maximum energy density (J/m^3) to use for microstructure simulations. Energy density is
+            defined as laser power / (layer thickness * scan speed * hatch spacing).
+            Parameter combinations with an energy density above this value are not included.
         min_build_rate : float, default: None
             The minimum build rate (m^3/s) to use for microstructure simulations.
             Parameter combinations with a build rate below this value will not be included.

--- a/src/ansys/additive/core/parametric_study/parametric_utils.py
+++ b/src/ansys/additive/core/parametric_study/parametric_utils.py
@@ -73,7 +73,7 @@ def energy_density(
     Returns
     -------
     float
-        Volumetric energy density is returned. If input units are W, m/s, m, or m,
+        Volumetric energy density is returned. If input units are W, m/s, and m,
         the output units are J/m^3.
     """
     br = build_rate(scan_speed, layer_thickness, hatch_spacing)

--- a/src/ansys/additive/core/parametric_study/parametric_utils.py
+++ b/src/ansys/additive/core/parametric_study/parametric_utils.py
@@ -21,12 +21,8 @@
 # SOFTWARE.
 """Provides utility functions used during a parametric study."""
 
-from typing import Optional
 
-
-def build_rate(
-    scan_speed: float, layer_thickness: float, hatch_spacing: Optional[float] = None
-) -> float:
+def build_rate(scan_speed: float, layer_thickness: float, hatch_spacing: float) -> float:
     """Calculate the build rate.
 
     This is an approximate value useful for comparison but not for an accurate prediction
@@ -39,26 +35,23 @@ def build_rate(
         Laser scan speed.
     layer_thickness : float
         Powder deposit layer thickness.
-    hatch_spacing : float, default: None
+    hatch_spacing : float
         Distance between hatch scan lines.
 
     Returns
     -------
     float
-        Volumetric build rate is returned if hatch spacing is provided.
-        Otherwise, an area build rate is returned. If input units are m/s and m,
-        the output units are m^3/s or m^2/s.
+        Volumetric build rate is returned. If input units are m/s and m,
+        the output units are m^3/s.
     """
-    if hatch_spacing is None:
-        return scan_speed * layer_thickness
-    return scan_speed * layer_thickness * hatch_spacing
+    return round(scan_speed * layer_thickness * hatch_spacing, 16)
 
 
 def energy_density(
     laser_power: float,
     scan_speed: float,
     layer_thickness: float,
-    hatch_spacing: Optional[float] = None,
+    hatch_spacing: float,
 ) -> float:
     """Calculate the energy density.
 
@@ -74,15 +67,14 @@ def energy_density(
         Laser scan speed.
     layer_thickness : float
         Powder deposit layer thickness.
-    hatch_spacing : float, default: None
+    hatch_spacing : float
         Distance between hatch scan lines.
 
     Returns
     -------
     float
-        Volumetric energy density is returned if hatch spacing is provided.
-        Otherwise an area energy density is returned. If input units are W, m/s, m, or m,
-        the output units are J/m^3 or J/m^2.
+        Volumetric energy density is returned. If input units are W, m/s, m, or m,
+        the output units are J/m^3.
     """
     br = build_rate(scan_speed, layer_thickness, hatch_spacing)
     return laser_power / br if br else float("nan")

--- a/tests/parametric_study/test_parametric_study.py
+++ b/tests/parametric_study/test_parametric_study.py
@@ -229,10 +229,6 @@ def test_add_summaries_with_single_bead_summary_adds_row(
         material=material,
     )
     summary = SingleBeadSummary(input, melt_pool_msg, None)
-    expected_build_rate = build_rate(
-        machine.scan_speed,
-        machine.layer_thickness,
-    )
     median_mp = summary.melt_pool.data_frame().median()
     expected_dw = (
         median_mp[MeltPoolColumnNames.REFERENCE_DEPTH]
@@ -266,8 +262,8 @@ def test_add_summaries_with_single_bead_summary_adds_row(
     assert row[ColumnNames.ROTATION_ANGLE] == machine.layer_rotation_angle
     assert row[ColumnNames.STRIPE_WIDTH] == machine.slicing_stripe_width
     assert row[ColumnNames.TYPE] == SimulationType.SINGLE_BEAD
-    assert row[ColumnNames.BUILD_RATE] == expected_build_rate
-    assert row[ColumnNames.ENERGY_DENSITY] == machine.laser_power / expected_build_rate
+    assert row[ColumnNames.BUILD_RATE] == None
+    assert row[ColumnNames.ENERGY_DENSITY] == None
     assert row[ColumnNames.SINGLE_BEAD_LENGTH] == 0.01
     assert row[ColumnNames.MELT_POOL_DEPTH] == median_mp[MeltPoolColumnNames.DEPTH]
     assert row[ColumnNames.MELT_POOL_WIDTH] == median_mp[MeltPoolColumnNames.WIDTH]
@@ -442,10 +438,6 @@ def test_add_summaries_overwrites_duplicate_entries_with_simulation_status_compl
     )
     melt_pool_msg = test_utils.get_test_melt_pool_message()
     summary = SingleBeadSummary(input_sb_1, melt_pool_msg, None)
-    expected_build_rate = build_rate(
-        machine.scan_speed,
-        machine.layer_thickness,
-    )
     median_mp = summary.melt_pool.data_frame().median()
     expected_dw = (
         median_mp[MeltPoolColumnNames.REFERENCE_DEPTH]
@@ -480,8 +472,8 @@ def test_add_summaries_overwrites_duplicate_entries_with_simulation_status_compl
     assert row[ColumnNames.ROTATION_ANGLE] == machine.layer_rotation_angle
     assert row[ColumnNames.STRIPE_WIDTH] == machine.slicing_stripe_width
     assert row[ColumnNames.TYPE] == SimulationType.SINGLE_BEAD
-    assert row[ColumnNames.BUILD_RATE] == expected_build_rate
-    assert row[ColumnNames.ENERGY_DENSITY] == machine.laser_power / expected_build_rate
+    assert row[ColumnNames.BUILD_RATE] == None
+    assert row[ColumnNames.ENERGY_DENSITY] == None
     assert row[ColumnNames.SINGLE_BEAD_LENGTH] == 0.01
     assert row[ColumnNames.MELT_POOL_DEPTH] == median_mp[MeltPoolColumnNames.DEPTH]
     assert row[ColumnNames.MELT_POOL_WIDTH] == median_mp[MeltPoolColumnNames.WIDTH]
@@ -607,13 +599,13 @@ def test_generate_single_bead_permutations_creates_permutations(
                             & (df[ColumnNames.ROTATION_ANGLE].isnull())
                             & (df[ColumnNames.HATCH_SPACING].isnull())
                             & (df[ColumnNames.STRIPE_WIDTH].isnull())
-                            & (df[ColumnNames.ENERGY_DENSITY].notnull())
-                            & (df[ColumnNames.BUILD_RATE].notnull())
+                            & (df[ColumnNames.ENERGY_DENSITY].isnull())
+                            & (df[ColumnNames.BUILD_RATE].isnull())
                             & (df[ColumnNames.SINGLE_BEAD_LENGTH] == bead_length)
                         )
 
 
-def test_generate_single_bead_permutations_filters_by_energy_density(
+def test_generate_single_bead_permutations_filters_by_pv_ratio(
     tmp_path: pytest.TempPathFactory,
 ):
     # arrange
@@ -621,16 +613,16 @@ def test_generate_single_bead_permutations_filters_by_energy_density(
     powers = [50, 250, 700]
     scan_speeds = [1]
     layer_thicknesses = [50e-6]
-    min_energy_density = 1.1e6
-    max_energy_density = 5.1e6
+    min_pv_ratio = 100
+    max_pv_ratio = 400
 
     # act
     study.generate_single_bead_permutations(
         powers,
         scan_speeds,
         layer_thicknesses=layer_thicknesses,
-        min_area_energy_density=min_energy_density,
-        max_area_energy_density=max_energy_density,
+        min_pv_ratio=min_pv_ratio,
+        max_pv_ratio=max_pv_ratio,
     )
 
     # assert

--- a/tests/parametric_study/test_parametric_utils.py
+++ b/tests/parametric_study/test_parametric_utils.py
@@ -30,7 +30,6 @@ def test_build_rate_calculates_correctly():
     # act
     # assert
     assert build_rate(2, 3, 4) == 24
-    assert build_rate(2, 3) == 6
 
 
 def test_energy_density_calulcates_correctly():
@@ -38,5 +37,4 @@ def test_energy_density_calulcates_correctly():
     # act
     # assert
     assert energy_density(24, 2, 3, 4) == 1
-    assert energy_density(6, 2, 3) == 1
     assert math.isnan(energy_density(6, 0, 3, 4))


### PR DESCRIPTION
- Update methods for `Single Bead` simulations to have the `energy density` and `build rate` as `None`
- Make `hatch_spacing` no longer optional for calculating `build_rate`
- Update methods for `Single Bead` simulations to use `pv_ratio` instead of `area_energy_density` wherever applicable
- Update unit tests and doc strings