### PR TITLE
Check for invalid material when importing from CSV

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-additive-core"
-version = "0.19.dev29"
+version = "0.19.dev30"
 description = "A Python client for the Ansys Additive service"
 readme = "README.rst"
 requires-python = ">=3.10,<4"

--- a/src/ansys/additive/core/parametric_study/parametric_study.py
+++ b/src/ansys/additive/core/parametric_study/parametric_study.py
@@ -1661,14 +1661,26 @@ class ParametricStudy:
         except Exception as e:
             raise ValueError(f"Unable to read CSV file: {e}")
 
-        columns = [getattr(ColumnNames, k) for k in ColumnNames.__dict__ if not k.startswith("_")]
-        required_columns = [col for col in columns if col != ColumnNames.PV_RATIO]
+        columns = set(
+            [getattr(ColumnNames, k) for k in ColumnNames.__dict__ if not k.startswith("_")]
+        )
+        # Older versions of the CSV file may not have the PV_RATIO column
+        columns.remove(ColumnNames.PV_RATIO)
 
-        if all([set(df.columns) == set(required_columns)]):
+        if not set(df.columns).issuperset(columns):
+            raise ValueError(
+                f"CSV is missing expected columns: {', '.join(str(v) for v in (columns - set(df.columns)))}"
+            )
+
+        if ColumnNames.PV_RATIO not in df:
             df = ParametricStudy._add_pv_ratio(df)
 
-        if not all([set(df.columns) == set(columns)]):
-            raise ValueError("CSV file does not have the expected columns.")
+        # check material name
+        csv_material = str(df[ColumnNames.MATERIAL].iloc[0])
+        if self.material_name and not csv_material.lower() == self.material_name.lower():
+            raise ValueError(
+                f"Material in CSV '{csv_material}' does not match study material '{self.material_name}'"
+            )
 
         # check valid inputs
         drop_indices, error_list = list(), list()


### PR DESCRIPTION
This PR:
* Checks for an invalid material name in an imported CSV
* Adds missing column names to the error message when imported CSV is invalid