### PR TITLE
ci(release): add environment

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -215,6 +215,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build-library]
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: "Download the library artifacts from build-library step"
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0


### PR DESCRIPTION
This pull-request adds a release environment for securing releases. It requests a manual approval from maintainers before proceeding with the upload of the run of the jobs.