### PR TITLE
ci: remove log upload from artifacts

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -190,15 +190,8 @@ jobs:
         if: ${{ always() }}
         run: |  # zizmor: ignore[template-injection]
           docker stop ${{ env.ANSYS_PRODUCT_CONTAINER }}
-          docker logs ${{ env.ANSYS_PRODUCT_CONTAINER }} >> docker-logs.txt
+          docker logs ${{ env.ANSYS_PRODUCT_CONTAINER }}
           docker rm ${{ env.ANSYS_PRODUCT_CONTAINER }}
-
-      - name: "Upload container logs as artifacts"
-        if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: docker-logs.txt
-          path: docker-logs.txt
 
   build-library:
     name: "Build library artifacts"


### PR DESCRIPTION
@deleon117 @pkrull-ansys -- please accept this PR. We need to avoid uploading the server logs as artifacts based on internal guidance. The logs can be visualized directly on the workflow as per the previous step